### PR TITLE
Absolute URL Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ let package = Package(
 
 ```swift
 let url = URL(string: "https://api.agify.io")!
-let client = URLSessionClient(baseURL: url)
+let client = BaseURLSessionClient(baseURL: url)
 let request = Get(queryItems: [URLQueryItem(name: "name", value: "bob")])
 let response = try await client.request(request)
 ```

--- a/Sources/SessionPlus/Deprecated/Downloader.swift
+++ b/Sources/SessionPlus/Deprecated/Downloader.swift
@@ -7,7 +7,7 @@ import UIKit
 #endif
 
 /// A wrapper for `URLSession` similar to `WebAPI` for general purpose downloading of data and images.
-@available(*, deprecated, message: "This will be removed in future versions of SessionPlus.")
+@available(*, deprecated, message: "Use `AbsoluteURLSessionClient` with `URLSessionConfiguration.cachingElseLoad()`.")
 open class Downloader {
     
     public typealias DataCompletion = (_ statusCode: Int, _ responseData: Data?, _ error: Error?) -> Void

--- a/Sources/SessionPlus/Extensions/URLCache+SessionPlus.swift
+++ b/Sources/SessionPlus/Extensions/URLCache+SessionPlus.swift
@@ -1,0 +1,42 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public extension URLCache {
+    enum Capacity {
+        case bytes(Int)
+        case megabytes(Int)
+        case gigabytes(Int)
+        
+        public static var twentyFiveMB: Capacity = .megabytes(25)
+        public static var twoHundredMB: Capacity = .megabytes(200)
+        
+        public var bytes: Int {
+            switch self {
+            case .bytes(let value):
+                return value
+            case .megabytes(let value):
+                return value * (1024 * 1024)
+            case .gigabytes(let value):
+                return value * (1024 * 1024 * 1024)
+            }
+        }
+    }
+    
+    convenience init(memoryCapacity: Capacity = .twentyFiveMB, diskCapacity: Capacity = .twoHundredMB) {
+        #if canImport(FoundationNetworking)
+        self.init(memoryCapacity: memoryCapacity.bytes, diskCapacity: diskCapacity.bytes, diskPath: "SessionPlusCache")
+        #else
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+            self.init(memoryCapacity: memoryCapacity.bytes, diskCapacity: diskCapacity.bytes)
+        } else {
+            #if targetEnvironment(macCatalyst)
+            self.init(memoryCapacity: memoryCapacity.bytes, diskCapacity: diskCapacity.bytes)
+            #else
+            self.init(memoryCapacity: memoryCapacity.bytes, diskCapacity: diskCapacity.bytes, diskPath: "SessionPlusCache")
+            #endif
+        }
+        #endif
+    }
+}

--- a/Sources/SessionPlus/Extensions/URLRequest+SessionPlus.swift
+++ b/Sources/SessionPlus/Extensions/URLRequest+SessionPlus.swift
@@ -9,8 +9,37 @@ public extension URLRequest {
     /// - parameters:
     ///   - request: `Request` parameters used to customize the request.
     ///   - baseUrl: The root of the API address.
-    init(request: Request, baseUrl: URL) throws {
-        self.init(url: try request.url(using: baseUrl))
+    init(request: Request, baseUrl: URL? = nil) throws {
+        let url: URL
+        switch request.address {
+        case .absolute(let value):
+            url = value
+        case .path(let value):
+            guard let baseURL = baseUrl else {
+                throw URLError(.badURL)
+            }
+            
+            let pathUrl = baseURL.appendingPathComponent(value)
+            
+            guard let queryItems = request.queryItems else {
+                url = pathUrl
+                break
+            }
+            
+            guard var components = URLComponents(url: pathUrl, resolvingAgainstBaseURL: false) else {
+                throw URLError(.badURL)
+            }
+            
+            components.queryItems = queryItems
+            
+            guard let _url = components.url else {
+                throw URLError(.badURL)
+            }
+            
+            url = _url
+        }
+        
+        self.init(url: url)
         
         httpMethod = request.method.rawValue
         setValue(Header.dateFormatter.string(from: Date()), forHeader: .date)

--- a/Sources/SessionPlus/Extensions/URLSessionConfiguration+SessionPlus.swift
+++ b/Sources/SessionPlus/Extensions/URLSessionConfiguration+SessionPlus.swift
@@ -1,0 +1,17 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public extension URLSessionConfiguration {
+    /// A `URLSessionConfiguration` which includes a `URLCache` and has the `.returnCacheDataElseLoad` policy applied.
+    static func cachingElseLoad(
+        memoryCapacity: URLCache.Capacity = .twentyFiveMB,
+        diskCapacity: URLCache.Capacity = .twoHundredMB
+    ) -> URLSessionConfiguration {
+        let configuration: URLSessionConfiguration = .default
+        configuration.urlCache = URLCache(memoryCapacity: memoryCapacity, diskCapacity: diskCapacity)
+        configuration.requestCachePolicy = .returnCacheDataElseLoad
+        return configuration
+    }
+}

--- a/Sources/SessionPlus/Implementation/AbsoluteURLSessionClient.swift
+++ b/Sources/SessionPlus/Implementation/AbsoluteURLSessionClient.swift
@@ -1,0 +1,75 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+#if canImport(Combine)
+import Combine
+#endif
+
+/// A `Client` implementation that operates expecting all requests use _absolute_ urls.
+open class AbsoluteURLSessionClient: Client {
+    
+    public let session: URLSession
+    
+    public init(sessionConfiguration: URLSessionConfiguration = .default, sessionDelegate: URLSessionDelegate? = nil) {
+        self.session = URLSession(configuration: sessionConfiguration, delegate: sessionDelegate, delegateQueue: nil)
+    }
+    
+    #if swift(>=5.5.2) && (os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+    /// Implementation that uses the `URLSession` async/await concurrency apis for handling a `Request`/`Response` interaction.
+    ///
+    /// The `URLSession` api is only available on Apple platforms, as the `FoundationNetworking` version has not been updated.
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    public func performRequest(_ request: Request) async throws -> Response {
+        let urlRequest = try URLRequest(request: request)
+        let sessionResponse = try await session.data(for: urlRequest)
+        return AnyResponse(statusCode: sessionResponse.1.statusCode, headers: sessionResponse.1.headers, data: sessionResponse.0)
+    }
+    #endif
+    
+    #if canImport(Combine)
+    /// Implementation that uses the `URLSession.DataTaskPublisher` to handle the `Request`/`Response` interaction.
+    public func performRequest(_ request: Request) -> AnyPublisher<Response, Error> {
+        let urlRequest: URLRequest
+        do {
+            urlRequest = try URLRequest(request: request)
+        } catch {
+            return Fail(outputType: Response.self, failure: error).eraseToAnyPublisher()
+        }
+        
+        return session
+            .dataTaskPublisher(for: urlRequest)
+            .tryMap { taskResponse -> Response in
+                AnyResponse(statusCode: taskResponse.response.statusCode, headers: taskResponse.response.headers, data: taskResponse.data)
+            }
+            .eraseToAnyPublisher()
+    }
+    #endif
+    
+    /// Implementation that uses the default `URLSessionDataTask` methods for handling a `Request`/`Response` interaction.
+    public func performRequest(_ request: Request, completion: @escaping (Result<Response, Error>) -> Void) {
+        let urlRequest: URLRequest
+        do {
+            urlRequest = try URLRequest(request: request)
+        } catch {
+            completion(.failure(error))
+            return
+        }
+        
+        session.dataTask(with: urlRequest) { data, urlResponse, error in
+            guard error == nil else {
+                completion(.failure(error!))
+                return
+            }
+            
+            guard let httpResponse = urlResponse else {
+                completion(.failure(URLError(.cannotParseResponse)))
+                return
+            }
+            
+            let response = AnyResponse(statusCode: httpResponse.statusCode, headers: httpResponse.headers, data: data ?? Data())
+            completion(.success(response))
+        }
+        .resume()
+    }
+}

--- a/Sources/SessionPlus/Implementation/AnyRequest.swift
+++ b/Sources/SessionPlus/Implementation/AnyRequest.swift
@@ -38,7 +38,7 @@ public struct AnyRequest: Request {
     }
     
     public init(
-        path: String = "",
+        path: String,
         method: Method = .get,
         headers: Headers? = nil,
         queryItems: [URLQueryItem]? = nil,
@@ -52,7 +52,7 @@ public struct AnyRequest: Request {
     }
     
     public init<E>(
-        path: String = "",
+        path: String,
         method: Method = .get,
         headers: Headers? = nil,
         queryItems: [URLQueryItem]? = nil,
@@ -60,6 +60,35 @@ public struct AnyRequest: Request {
         using encoder: JSONEncoder = JSONEncoder()
     ) throws where E: Encodable {
         self.address = .path(path)
+        self.method = method
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = try encoder.encode(encoding)
+    }
+    
+    public init(
+        url: URL,
+        method: Method = .get,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        body: Data? = nil
+    ) {
+        self.address = .absolute(url)
+        self.method = method
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = body
+    }
+    
+    public init<E>(
+        url: URL,
+        method: Method = .get,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        encoding: E,
+        using encoder: JSONEncoder = JSONEncoder()
+    ) throws where E: Encodable {
+        self.address = .absolute(url)
         self.method = method
         self.headers = headers
         self.queryItems = queryItems

--- a/Sources/SessionPlus/Implementation/AnyRequest.swift
+++ b/Sources/SessionPlus/Implementation/AnyRequest.swift
@@ -2,11 +2,40 @@ import Foundation
 
 /// Generalized implementation of a `Request`.
 public struct AnyRequest: Request {
-    public let path: String
+    public let address: Address
     public let method: Method
     public let headers: Headers?
     public let queryItems: [URLQueryItem]?
     public let body: Data?
+    
+    public init(
+        address: Address = .path(""),
+        method: Method = .get,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        body: Data? = nil
+    ) {
+        self.address = address
+        self.method = method
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = body
+    }
+    
+    public init<E>(
+        address: Address = .path(""),
+        method: Method = .get,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        encoding: E,
+        using encoder: JSONEncoder = JSONEncoder()
+    ) throws where E: Encodable {
+        self.address = address
+        self.method = method
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = try encoder.encode(encoding)
+    }
     
     public init(
         path: String = "",
@@ -15,7 +44,7 @@ public struct AnyRequest: Request {
         queryItems: [URLQueryItem]? = nil,
         body: Data? = nil
     ) {
-        self.path = path
+        self.address = .path(path)
         self.method = method
         self.headers = headers
         self.queryItems = queryItems
@@ -30,7 +59,7 @@ public struct AnyRequest: Request {
         encoding: E,
         using encoder: JSONEncoder = JSONEncoder()
     ) throws where E: Encodable {
-        self.path = path
+        self.address = .path(path)
         self.method = method
         self.headers = headers
         self.queryItems = queryItems

--- a/Sources/SessionPlus/Implementation/BaseURLSessionClient.swift
+++ b/Sources/SessionPlus/Implementation/BaseURLSessionClient.swift
@@ -6,7 +6,11 @@ import FoundationNetworking
 import Combine
 #endif
 
-open class URLSessionClient: Client {
+@available(*, deprecated, renamed: "BaseURLSessionClient")
+public typealias URLSessionClient = BaseURLSessionClient
+
+/// A `Client` implementation that operates with a _base_ URL which all requests use to form the address.
+open class BaseURLSessionClient: Client {
     
     open var baseURL: URL
     public let session: URLSession

--- a/Sources/SessionPlus/Implementation/Delete.swift
+++ b/Sources/SessionPlus/Implementation/Delete.swift
@@ -34,7 +34,7 @@ public struct Delete: Request {
     }
     
     public init(
-        path: String = "",
+        path: String,
         headers: Headers? = nil,
         queryItems: [URLQueryItem]? = nil,
         body: Data? = nil
@@ -46,13 +46,38 @@ public struct Delete: Request {
     }
     
     public init<E>(
-        path: String = "",
+        path: String,
         headers: Headers? = nil,
         queryItems: [URLQueryItem]? = nil,
         encoding: E,
         using encoder: JSONEncoder = JSONEncoder()
     ) throws where E: Encodable {
         self.address = .path(path)
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = try encoder.encode(encoding)
+    }
+    
+    public init(
+        url: URL,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        body: Data? = nil
+    ) {
+        self.address = .absolute(url)
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = body
+    }
+    
+    public init<E>(
+        url: URL,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        encoding: E,
+        using encoder: JSONEncoder = JSONEncoder()
+    ) throws where E: Encodable {
+        self.address = .absolute(url)
         self.headers = headers
         self.queryItems = queryItems
         self.body = try encoder.encode(encoding)

--- a/Sources/SessionPlus/Implementation/Delete.swift
+++ b/Sources/SessionPlus/Implementation/Delete.swift
@@ -2,11 +2,36 @@ import Foundation
 
 /// A convenience `Request` that uses `Method.delete`.
 public struct Delete: Request {
-    public let path: String
+    public let address: Address
     public let method: Method = .delete
     public let headers: Headers?
     public let queryItems: [URLQueryItem]?
     public let body: Data?
+    
+    public init(
+        address: Address = .path(""),
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        body: Data? = nil
+    ) {
+        self.address = address
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = body
+    }
+    
+    public init<E>(
+        address: Address = .path(""),
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        encoding: E,
+        using encoder: JSONEncoder = JSONEncoder()
+    ) throws where E: Encodable {
+        self.address = address
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = try encoder.encode(encoding)
+    }
     
     public init(
         path: String = "",
@@ -14,7 +39,7 @@ public struct Delete: Request {
         queryItems: [URLQueryItem]? = nil,
         body: Data? = nil
     ) {
-        self.path = path
+        self.address = .path(path)
         self.headers = headers
         self.queryItems = queryItems
         self.body = body
@@ -27,7 +52,7 @@ public struct Delete: Request {
         encoding: E,
         using encoder: JSONEncoder = JSONEncoder()
     ) throws where E: Encodable {
-        self.path = path
+        self.address = .path(path)
         self.headers = headers
         self.queryItems = queryItems
         self.body = try encoder.encode(encoding)

--- a/Sources/SessionPlus/Implementation/Get.swift
+++ b/Sources/SessionPlus/Implementation/Get.swift
@@ -2,11 +2,36 @@ import Foundation
 
 /// A convenience `Request` that uses `Method.get`.
 public struct Get: Request {
-    public let path: String
+    public let address: Address
     public let method: Method = .get
     public let headers: Headers?
     public let queryItems: [URLQueryItem]?
     public let body: Data?
+    
+    public init(
+        address: Address = .path(""),
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        body: Data? = nil
+    ) {
+        self.address = address
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = body
+    }
+    
+    public init<E>(
+        address: Address = .path(""),
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        encoding: E,
+        using encoder: JSONEncoder = JSONEncoder()
+    ) throws where E: Encodable {
+        self.address = address
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = try encoder.encode(encoding)
+    }
     
     public init(
         path: String = "",
@@ -14,7 +39,7 @@ public struct Get: Request {
         queryItems: [URLQueryItem]? = nil,
         body: Data? = nil
     ) {
-        self.path = path
+        self.address = .path(path)
         self.headers = headers
         self.queryItems = queryItems
         self.body = body
@@ -27,7 +52,7 @@ public struct Get: Request {
         encoding: E,
         using encoder: JSONEncoder = JSONEncoder()
     ) throws where E: Encodable {
-        self.path = path
+        self.address = .path(path)
         self.headers = headers
         self.queryItems = queryItems
         self.body = try encoder.encode(encoding)

--- a/Sources/SessionPlus/Implementation/Get.swift
+++ b/Sources/SessionPlus/Implementation/Get.swift
@@ -34,7 +34,7 @@ public struct Get: Request {
     }
     
     public init(
-        path: String = "",
+        path: String,
         headers: Headers? = nil,
         queryItems: [URLQueryItem]? = nil,
         body: Data? = nil
@@ -46,13 +46,38 @@ public struct Get: Request {
     }
     
     public init<E>(
-        path: String = "",
+        path: String,
         headers: Headers? = nil,
         queryItems: [URLQueryItem]? = nil,
         encoding: E,
         using encoder: JSONEncoder = JSONEncoder()
     ) throws where E: Encodable {
         self.address = .path(path)
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = try encoder.encode(encoding)
+    }
+    
+    public init(
+        url: URL,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        body: Data? = nil
+    ) {
+        self.address = .absolute(url)
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = body
+    }
+    
+    public init<E>(
+        url: URL,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        encoding: E,
+        using encoder: JSONEncoder = JSONEncoder()
+    ) throws where E: Encodable {
+        self.address = .absolute(url)
         self.headers = headers
         self.queryItems = queryItems
         self.body = try encoder.encode(encoding)

--- a/Sources/SessionPlus/Implementation/PNGImageFormDataRequest.swift
+++ b/Sources/SessionPlus/Implementation/PNGImageFormDataRequest.swift
@@ -30,7 +30,7 @@ public struct PNGImageFormDataRequest: Request {
     }
     
     public init(
-        path: String = "",
+        path: String,
         method: Method = .post,
         headers: Headers? = nil,
         queryItems: [URLQueryItem]? = nil,
@@ -39,6 +39,27 @@ public struct PNGImageFormDataRequest: Request {
         imageData: Data
     ) {
         self.address = .path(path)
+        self.method = method
+        self.queryItems = queryItems
+        
+        let data = Self.data(field: field, filename: filename, imageData: imageData)
+        
+        var headers = headers ?? [:]
+        headers[.contentType] = "multipart/form-data; boundary=\(data.boundary)"
+        self.headers = headers
+        self.body = data.data
+    }
+    
+    public init(
+        url: URL,
+        method: Method = .post,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        field: String = "image",
+        filename: String = "image.png",
+        imageData: Data
+    ) {
+        self.address = .absolute(url)
         self.method = method
         self.queryItems = queryItems
         

--- a/Sources/SessionPlus/Implementation/Patch.swift
+++ b/Sources/SessionPlus/Implementation/Patch.swift
@@ -2,11 +2,36 @@ import Foundation
 
 /// A convenience `Request` that uses `Method.patch`.
 public struct Patch: Request {
-    public let path: String
+    public let address: Address
     public let method: Method = .patch
     public let headers: Headers?
     public let queryItems: [URLQueryItem]?
     public let body: Data?
+    
+    public init(
+        address: Address = .path(""),
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        body: Data? = nil
+    ) {
+        self.address = address
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = body
+    }
+    
+    public init<E>(
+        address: Address = .path(""),
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        encoding: E,
+        using encoder: JSONEncoder = JSONEncoder()
+    ) throws where E: Encodable {
+        self.address = address
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = try encoder.encode(encoding)
+    }
     
     public init(
         path: String = "",
@@ -14,7 +39,7 @@ public struct Patch: Request {
         queryItems: [URLQueryItem]? = nil,
         body: Data? = nil
     ) {
-        self.path = path
+        self.address = .path(path)
         self.headers = headers
         self.queryItems = queryItems
         self.body = body
@@ -27,7 +52,7 @@ public struct Patch: Request {
         encoding: E,
         using encoder: JSONEncoder = JSONEncoder()
     ) throws where E: Encodable {
-        self.path = path
+        self.address = .path(path)
         self.headers = headers
         self.queryItems = queryItems
         self.body = try encoder.encode(encoding)

--- a/Sources/SessionPlus/Implementation/Patch.swift
+++ b/Sources/SessionPlus/Implementation/Patch.swift
@@ -34,7 +34,7 @@ public struct Patch: Request {
     }
     
     public init(
-        path: String = "",
+        path: String,
         headers: Headers? = nil,
         queryItems: [URLQueryItem]? = nil,
         body: Data? = nil
@@ -46,13 +46,38 @@ public struct Patch: Request {
     }
     
     public init<E>(
-        path: String = "",
+        path: String,
         headers: Headers? = nil,
         queryItems: [URLQueryItem]? = nil,
         encoding: E,
         using encoder: JSONEncoder = JSONEncoder()
     ) throws where E: Encodable {
         self.address = .path(path)
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = try encoder.encode(encoding)
+    }
+    
+    public init(
+        url: URL,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        body: Data? = nil
+    ) {
+        self.address = .absolute(url)
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = body
+    }
+    
+    public init<E>(
+        url: URL,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        encoding: E,
+        using encoder: JSONEncoder = JSONEncoder()
+    ) throws where E: Encodable {
+        self.address = .absolute(url)
         self.headers = headers
         self.queryItems = queryItems
         self.body = try encoder.encode(encoding)

--- a/Sources/SessionPlus/Implementation/Post.swift
+++ b/Sources/SessionPlus/Implementation/Post.swift
@@ -2,11 +2,36 @@ import Foundation
 
 /// A convenience `Request` that uses `Method.post`.
 public struct Post: Request {
-    public let path: String
+    public let address: Address
     public let method: Method = .post
     public let headers: Headers?
     public let queryItems: [URLQueryItem]?
     public let body: Data?
+    
+    public init(
+        address: Address = .path(""),
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        body: Data? = nil
+    ) {
+        self.address = address
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = body
+    }
+    
+    public init<E>(
+        address: Address = .path(""),
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        encoding: E,
+        using encoder: JSONEncoder = JSONEncoder()
+    ) throws where E: Encodable {
+        self.address = address
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = try encoder.encode(encoding)
+    }
     
     public init(
         path: String = "",
@@ -14,7 +39,7 @@ public struct Post: Request {
         queryItems: [URLQueryItem]? = nil,
         body: Data? = nil
     ) {
-        self.path = path
+        self.address = .path(path)
         self.headers = headers
         self.queryItems = queryItems
         self.body = body
@@ -27,7 +52,7 @@ public struct Post: Request {
         encoding: E,
         using encoder: JSONEncoder = JSONEncoder()
     ) throws where E: Encodable {
-        self.path = path
+        self.address = .path(path)
         self.headers = headers
         self.queryItems = queryItems
         self.body = try encoder.encode(encoding)

--- a/Sources/SessionPlus/Implementation/Post.swift
+++ b/Sources/SessionPlus/Implementation/Post.swift
@@ -34,7 +34,7 @@ public struct Post: Request {
     }
     
     public init(
-        path: String = "",
+        path: String,
         headers: Headers? = nil,
         queryItems: [URLQueryItem]? = nil,
         body: Data? = nil
@@ -46,13 +46,38 @@ public struct Post: Request {
     }
     
     public init<E>(
-        path: String = "",
+        path: String,
         headers: Headers? = nil,
         queryItems: [URLQueryItem]? = nil,
         encoding: E,
         using encoder: JSONEncoder = JSONEncoder()
     ) throws where E: Encodable {
         self.address = .path(path)
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = try encoder.encode(encoding)
+    }
+    
+    public init(
+        url: URL,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        body: Data? = nil
+    ) {
+        self.address = .absolute(url)
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = body
+    }
+    
+    public init<E>(
+        url: URL,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        encoding: E,
+        using encoder: JSONEncoder = JSONEncoder()
+    ) throws where E: Encodable {
+        self.address = .absolute(url)
         self.headers = headers
         self.queryItems = queryItems
         self.body = try encoder.encode(encoding)

--- a/Sources/SessionPlus/Implementation/Put.swift
+++ b/Sources/SessionPlus/Implementation/Put.swift
@@ -34,7 +34,7 @@ public struct Put: Request {
     }
     
     public init(
-        path: String = "",
+        path: String,
         headers: Headers? = nil,
         queryItems: [URLQueryItem]? = nil,
         body: Data? = nil
@@ -46,13 +46,38 @@ public struct Put: Request {
     }
     
     public init<E>(
-        path: String = "",
+        path: String,
         headers: Headers? = nil,
         queryItems: [URLQueryItem]? = nil,
         encoding: E,
         using encoder: JSONEncoder = JSONEncoder()
     ) throws where E: Encodable {
         self.address = .path(path)
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = try encoder.encode(encoding)
+    }
+    
+    public init(
+        url: URL,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        body: Data? = nil
+    ) {
+        self.address = .absolute(url)
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = body
+    }
+    
+    public init<E>(
+        url: URL,
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        encoding: E,
+        using encoder: JSONEncoder = JSONEncoder()
+    ) throws where E: Encodable {
+        self.address = .absolute(url)
         self.headers = headers
         self.queryItems = queryItems
         self.body = try encoder.encode(encoding)

--- a/Sources/SessionPlus/Implementation/Put.swift
+++ b/Sources/SessionPlus/Implementation/Put.swift
@@ -2,11 +2,36 @@ import Foundation
 
 /// A convenience `Request` that uses `Method.put`.
 public struct Put: Request {
-    public let path: String
+    public let address: Address
     public let method: Method = .put
     public let headers: Headers?
     public let queryItems: [URLQueryItem]?
     public let body: Data?
+    
+    public init(
+        address: Address = .path(""),
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        body: Data? = nil
+    ) {
+        self.address = address
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = body
+    }
+    
+    public init<E>(
+        address: Address = .path(""),
+        headers: Headers? = nil,
+        queryItems: [URLQueryItem]? = nil,
+        encoding: E,
+        using encoder: JSONEncoder = JSONEncoder()
+    ) throws where E: Encodable {
+        self.address = address
+        self.headers = headers
+        self.queryItems = queryItems
+        self.body = try encoder.encode(encoding)
+    }
     
     public init(
         path: String = "",
@@ -14,7 +39,7 @@ public struct Put: Request {
         queryItems: [URLQueryItem]? = nil,
         body: Data? = nil
     ) {
-        self.path = path
+        self.address = .path(path)
         self.headers = headers
         self.queryItems = queryItems
         self.body = body
@@ -27,7 +52,7 @@ public struct Put: Request {
         encoding: E,
         using encoder: JSONEncoder = JSONEncoder()
     ) throws where E: Encodable {
-        self.path = path
+        self.address = .path(path)
         self.headers = headers
         self.queryItems = queryItems
         self.body = try encoder.encode(encoding)

--- a/Sources/SessionPlus/Interface/Address.swift
+++ b/Sources/SessionPlus/Interface/Address.swift
@@ -1,0 +1,14 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// The method in which a `Request` URL is described and constructed.
+public enum Address: Codable {
+    /// The full URL including any query components.
+    case absolute(URL)
+    /// Routing path extension.
+    ///
+    /// This is appended to a _base URL_ instance to create an 'absolute path' to a resource.
+    case path(String)
+}

--- a/Sources/SessionPlus/Interface/Request.swift
+++ b/Sources/SessionPlus/Interface/Request.swift
@@ -15,25 +15,25 @@ public protocol Request {
     var queryItems: [URLQueryItem]? { get }
     /// Binary data that is attached to the `URLRequest`.
     var body: Data? { get }
-    
-    /// Instructs the request to create an 'absolute' URL given a particular base/root `URL`.
-    func url(using baseURL: URL?) throws -> URL
 }
 
 public extension Request {
     /// Routing path extension.
     ///
     /// This is appended to a _base URL_ instance to create an 'absolute path' to a resource.
-    @available(*, deprecated, renamed: "address")
     var path: String {
-        guard case let .path(path) = address else {
-            return ""
+        switch address {
+        case .absolute(let url):
+            return URLComponents(url: url, resolvingAgainstBaseURL: false)?.path ?? ""
+        case .path(let path):
+            return path
         }
-        
-        return path
     }
     
+    /// Instructs the request to create an 'absolute' URL given a particular base/root `URL`.
+    ///
     /// The default implementation appends the `path` and any `queryItems`.
+    @available(*, deprecated, message: "URLRequest(request:baseUrl:) should be used directly.")
     func url(using baseURL: URL? = nil) throws -> URL {
         switch address {
         case .absolute(let url):

--- a/Sources/SessionPlus/Interface/Request.swift
+++ b/Sources/SessionPlus/Interface/Request.swift
@@ -5,10 +5,8 @@ import FoundationNetworking
 
 /// The encapsulation of information needed to perform a request against an HTTP/REST service endpoint.
 public protocol Request {
-    /// Routing path extension.
-    ///
-    /// This is appended to a _base URL_ instance to create an 'absolute path' to a resource.
-    var path: String { get }
+    /// Method used to address the request.
+    var address: Address { get }
     /// The HTTP verb (action/method) associated with the request.
     var method: Method { get }
     /// Custom headers to provide in the created `URLRequest`.
@@ -19,29 +17,50 @@ public protocol Request {
     var body: Data? { get }
     
     /// Instructs the request to create an 'absolute' URL given a particular base/root `URL`.
-    func url(using baseURL: URL) throws -> URL
+    func url(using baseURL: URL?) throws -> URL
 }
 
 public extension Request {
+    /// Routing path extension.
+    ///
+    /// This is appended to a _base URL_ instance to create an 'absolute path' to a resource.
+    @available(*, deprecated, renamed: "address")
+    var path: String {
+        guard case let .path(path) = address else {
+            return ""
+        }
+        
+        return path
+    }
+    
     /// The default implementation appends the `path` and any `queryItems`.
-    func url(using baseURL: URL) throws -> URL {
-        let pathUrl = baseURL.appendingPathComponent(path)
-        
-        guard let queryItems = self.queryItems else {
-            return pathUrl
+    func url(using baseURL: URL? = nil) throws -> URL {
+        switch address {
+        case .absolute(let url):
+            return url
+        case .path(let path):
+            guard let baseURL = baseURL else {
+                throw URLError(.badURL)
+            }
+            
+            let pathUrl = baseURL.appendingPathComponent(path)
+            
+            guard let queryItems = self.queryItems else {
+                return pathUrl
+            }
+            
+            guard var components = URLComponents(url: pathUrl, resolvingAgainstBaseURL: false) else {
+                throw URLError(.badURL)
+            }
+            
+            components.queryItems = queryItems
+            
+            guard let url = components.url else {
+                throw URLError(.badURL)
+            }
+            
+            return url
         }
-        
-        guard var components = URLComponents(url: pathUrl, resolvingAgainstBaseURL: false) else {
-            throw URLError(.badURL)
-        }
-        
-        components.queryItems = queryItems
-        
-        guard let url = components.url else {
-            throw URLError(.badURL)
-        }
-        
-        return url
     }
     
     /// Appends (or overwrites) the **Authorization** key in the request headers.
@@ -53,6 +72,6 @@ public extension Request {
         var headers = self.headers ?? [:]
         headers[.authorization] = authorization.headerValue
         
-        return AnyRequest(path: path, method: method, headers: headers, queryItems: queryItems, body: body)
+        return AnyRequest(address: address, method: method, headers: headers, queryItems: queryItems, body: body)
     }
 }

--- a/Sources/SessionPlusEmulation/EmulatedClient.swift
+++ b/Sources/SessionPlusEmulation/EmulatedClient.swift
@@ -6,14 +6,14 @@ open class EmulatedClient: Client {
     public struct EmulatedRequest: Request, Identifiable, Codable {
         
         enum CodingKeys: String, CodingKey {
-            case path
+            case address
             case method
             case headers
             case queryItems
             case body
         }
         
-        public var path: String
+        public var address: Address
         public var method: SessionPlus.Method
         public var headers: Headers?
         public var queryItems: [URLQueryItem]?
@@ -29,7 +29,7 @@ open class EmulatedClient: Client {
         }
         
         public init(_ request: Request) {
-            path = request.path
+            address = request.address
             method = request.method
             headers = request.headers
             queryItems = request.queryItems
@@ -38,7 +38,7 @@ open class EmulatedClient: Client {
         
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            path = try container.decode(String.self, forKey: .path)
+            address = try container.decode(Address.self, forKey: .address)
             method = try container.decode(Method.self, forKey: .method)
             headers = try container.decodeIfPresent([String: String].self, forKey: .headers)
             queryItems = try container.decodeIfPresent([URLQueryItem].self, forKey: .queryItems)
@@ -47,7 +47,7 @@ open class EmulatedClient: Client {
         
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(path, forKey: .path)
+            try container.encode(address, forKey: .address)
             try container.encode(method, forKey: .method)
             try container.encodeIfPresent(headers as? [String: String], forKey: .headers)
             try container.encodeIfPresent(queryItems, forKey: .queryItems)

--- a/Tests/SessionPlusTests/MultipartFormDataTests.swift
+++ b/Tests/SessionPlusTests/MultipartFormDataTests.swift
@@ -9,7 +9,7 @@ final class MultipartFormDataTests: XCTestCase {
     func testPNGImageFormDataRequest() throws {
         let imageData = try XCTUnwrap(Data(base64Encoded: imageBase64))
         
-        let request = PNGImageFormDataRequest(filename: filename, imageData: imageData)
+        let request = PNGImageFormDataRequest(path: "", filename: filename, imageData: imageData)
         let contentType = try XCTUnwrap(request.headers?[.contentType] as? String)
         let boundary = contentType.suffix(32)
         let body = try XCTUnwrap(request.body)


### PR DESCRIPTION
Modifications to better support using _absolute URLs_.

The primary intent of the framework is to interact with JSON apis, but another very-common need is the ability to download random data or images from URLs outside of a primary API. This is what the deprecated `Downloader` was focused on.

The ability to interact with _non-base_ URLs has been brought forward and integrated into the overall solution. `Request` now has an `Address` enum which determines the type of addressing that will be used. The `URLSessionClient` has been renamed to `BaseURLSessionClient` to better indicate its usage, and a `AbsoluteURLSessionClient` implementation is now available.