### PR TITLE
Log Level State

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,6 +21,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
 
+    - name: Lint
+      if: ${{ runner.os == 'macOS' }}
+      shell: bash
+      run: swiftformat --lint . --reporter github-actions-log
+
     - name: Package Resolution
       shell: bash
       run: swift package resolve
@@ -32,3 +37,4 @@ jobs:
     - name: Test
       shell: bash
       run: swift test
+      

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "12dcbffc746ed2d6353a2a4cd30fd1cb40d74c958f9a8bc5cde1c4e2c6c2e8db",
+  "originHash" : "4ed52ad35390bafcb2ee6b1a0349c7a3dde293cf3f1917f38939b88d1327f9c9",
   "pins" : [
     {
       "identity" : "asyncplus",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
         "version" : "1.6.2"
+      }
+    },
+    {
+      "identity" : "swift-mutex",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swhitty/swift-mutex.git",
+      "state" : {
+        "revision" : "1770152df756b54c28ef1787df1e957d93cc62d5",
+        "version" : "0.0.6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-testing.git", branch: "swift-6.2-RELEASE"),
         .package(url: "https://github.com/richardpiazza/AsyncPlus.git", .upToNextMajor(from: "0.3.2")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"),
+        .package(url: "https://github.com/swhitty/swift-mutex.git", from: "0.0.6"),
     ],
     targets: [
         .target(
@@ -33,6 +34,7 @@ let package = Package(
             dependencies: [
                 .product(name: "AsyncPlus", package: "AsyncPlus"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "Mutex", package: "swift-mutex"),
             ],
         ),
         .target(

--- a/Sources/SessionPlus/Implementation/AbsoluteURLSessionClient.swift
+++ b/Sources/SessionPlus/Implementation/AbsoluteURLSessionClient.swift
@@ -7,16 +7,36 @@ import Logging
 /// A `Client` implementation that operates expecting all requests use _absolute_ urls.
 open class AbsoluteURLSessionClient: Client {
 
-    public var verboseLogging: Bool = false
+    @available(*, deprecated)
+    public var verboseLogging: Bool {
+        get { logLevel.value == .trace }
+        set { setLogLevel(newValue ? .trace : .debug) }
+    }
+
     public let session: URLSession
     private let logger: Logger = .sessionPlus
+    private let logLevel: ProtectedState = ProtectedState()
 
-    public init(sessionConfiguration: URLSessionConfiguration = .default, sessionDelegate: (any URLSessionDelegate)? = nil) {
-        session = URLSession(configuration: sessionConfiguration, delegate: sessionDelegate, delegateQueue: nil)
+    public init(
+        sessionConfiguration: URLSessionConfiguration = .default,
+        sessionDelegate: (any URLSessionDelegate)? = nil,
+    ) {
+        session = URLSession(
+            configuration: sessionConfiguration,
+            delegate: sessionDelegate, delegateQueue: nil,
+        )
+    }
+
+    public var logLevelStream: AsyncStream<Logger.Level> {
+        logLevel.asyncStream
+    }
+
+    public func setLogLevel(_ level: Logger.Level) {
+        logLevel.setValue(level)
     }
 
     public func performRequest(_ request: any Request) async throws -> any Response {
-        if verboseLogging {
+        if logLevel.value > .trace {
             logger.debug("HTTP Request", metadata: request.verboseMetadata)
         } else {
             logger.trace("HTTP Request", metadata: request.metadata)
@@ -46,7 +66,7 @@ open class AbsoluteURLSessionClient: Client {
             body: data,
         )
 
-        if verboseLogging {
+        if logLevel.value > .trace {
             logger.debug("HTTP Response", metadata: response.verboseMetadata)
         } else {
             logger.trace("HTTP Response", metadata: response.metadata)

--- a/Sources/SessionPlus/Implementation/ProtectedState.swift
+++ b/Sources/SessionPlus/Implementation/ProtectedState.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Logging
+import Mutex
+
+package class ProtectedState<T: Sendable>: @unchecked Sendable {
+    
+    private let state: Mutex<T>
+    private let subscribers: Mutex<[UUID: AsyncStream<T>.Continuation]> = Mutex([:])
+    
+    package init(_ initialValue: T) {
+        state = Mutex(initialValue)
+    }
+    
+    package var value: T {
+        state.withLock { $0 }
+    }
+    
+    package var asyncStream: AsyncStream<T> {
+        let id = UUID()
+        let asyncStream = AsyncStream.makeStream(of: T.self)
+        asyncStream.continuation.onTermination = { [weak self] _ in
+            self?.removeSubscriber(id)
+        }
+        addSubscriber(id, continuation: asyncStream.continuation)
+                
+        defer {
+            let level = state.withLock { $0 }
+            asyncStream.continuation.yield(level)
+        }
+        
+        return asyncStream.stream
+    }
+    
+    package func setValue(_ value: T) {
+        state.withLock { $0 = value }
+        let subscribers = subscribers.withLock { $0 }
+        for (_, continuation) in subscribers {
+            continuation.yield(value)
+        }
+    }
+    
+    private func addSubscriber(_ id: UUID, continuation: AsyncStream<T>.Continuation) {
+        subscribers.withLock {
+            $0[id] = continuation
+        }
+    }
+    
+    private func removeSubscriber(_ id: UUID) {
+        subscribers.withLock {
+            $0[id] = nil
+        }
+    }
+}
+
+extension ProtectedState where T == Logger.Level {
+    package convenience init(level: Logger.Level = .debug) {
+        self.init(level)
+    }
+}

--- a/Sources/SessionPlus/Interface/Client.swift
+++ b/Sources/SessionPlus/Interface/Client.swift
@@ -1,8 +1,19 @@
 import Foundation
 import Logging
 
+// TODO: `Sendable` Conformance
 public protocol Client {
+    @available(*, deprecated, message: "Direct state access should be avoided.")
     var verboseLogging: Bool { get set }
+
+    /// Provides an `AsyncStream` with the clients `Logger.Level` state.
+    var logLevelStream: AsyncStream<Logger.Level> { get }
+
+    /// Requests an adjustment to the `Client` logging level.
+    ///
+    /// The client implementations provided by this package primarily observe
+    /// `.trace`, `.debug`, & `.info`.
+    func setLogLevel(_ level: Logger.Level)
 
     /// Perform a network `Request`.
     ///
@@ -19,8 +30,11 @@ public extension Client {
     ///   - request: The details of the request to perform.
     ///   - decoder: The `JSONDecoder` that should be used to deserialize the result data.
     /// - returns: The decoded `Response` value.
-    func performRequest<Value>(_ request: any Request, using decoder: JSONDecoder = JSONDecoder()) async throws -> Value where Value: Decodable {
+    func performRequest<Content>(
+        _ request: any Request,
+        using decoder: JSONDecoder = JSONDecoder(),
+    ) async throws -> Content where Content: Decodable {
         let response = try await performRequest(request)
-        return try decoder.decode(Value.self, from: response.body)
+        return try decoder.decode(Content.self, from: response.body)
     }
 }


### PR DESCRIPTION
The `Client` protocol contained a mutable `verboseLogging` property. This make is difficult to adopt more strict concurrency settings as it exposes uncontrolled access to mutable state.

This is replaced with two additional properties:
* `logLevelStream: AsyncStream<Logger.Level> { get }` - an AsyncStream which yields the current and updated state of the logging level.
* `setLogLevel(_:)` - function which can be used to request a change in the logging level.