### PR TITLE
Removed AsyncPlus

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "4ed52ad35390bafcb2ee6b1a0349c7a3dde293cf3f1917f38939b88d1327f9c9",
+  "originHash" : "d14c26ef88f3df271cfc752f2a5d23a00bbd3bf48e6ccf01fea1d8afd9c26d7b",
   "pins" : [
-    {
-      "identity" : "asyncplus",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/richardpiazza/AsyncPlus.git",
-      "state" : {
-        "revision" : "ab486f6744539f8814296cc85a7cc317f165dfc0",
-        "version" : "0.3.2"
-      }
-    },
     {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-testing.git", branch: "swift-6.2-RELEASE"),
-        .package(url: "https://github.com/richardpiazza/AsyncPlus.git", .upToNextMajor(from: "0.3.2")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.2"),
         .package(url: "https://github.com/swhitty/swift-mutex.git", from: "0.0.6"),
     ],
@@ -32,7 +31,6 @@ let package = Package(
         .target(
             name: "SessionPlus",
             dependencies: [
-                .product(name: "AsyncPlus", package: "AsyncPlus"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Mutex", package: "swift-mutex"),
             ],


### PR DESCRIPTION
The package **AsyncPlus** was used to manage the `AsyncThrowingStream` and continuation. Now using the provided convenience API to manage internally.